### PR TITLE
test: Demonstrating a problem with IsNewState

### DIFF
--- a/src/BullOak.Repositories.EventStore.Test.Integration/Contexts/TestDataContext.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Contexts/TestDataContext.cs
@@ -16,6 +16,7 @@
 
         public Exception RecordedException { get; internal set; }
         public IHoldHigherOrder LatestLoadedState { get; internal set; }
+        public bool IsNewState { get; internal set; }
 
         public StreamReadResults LatestStreamReadResults { get; internal set; }
         public Dictionary<string, IManageSessionOf<IHoldHigherOrder>> NamedSessions { get; } = new();

--- a/src/BullOak.Repositories.EventStore.Test.Integration/Specification/OpenEventStream.feature
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Specification/OpenEventStream.feature
@@ -10,3 +10,4 @@ Scenario: Open a stream that does not exist
     Given a new stream
 	When I try to open the new stream
 	Then the session reports new state
+	And the session state is intialized

--- a/src/BullOak.Repositories.EventStore.Test.Integration/Specification/OpenEventStream.feature
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Specification/OpenEventStream.feature
@@ -1,0 +1,12 @@
+﻿Feature: OpenEventsStream
+	In order to persist using an event stream
+	As a developer using this new library
+	I want to be able to open an event stream
+
+Background:
+    Given the grpc protocol is being used
+
+Scenario: Open a stream that does not exist
+    Given a new stream
+	When I try to open the new stream
+	Then the session reports new state

--- a/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/StreamStepsDefinitions.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/StreamStepsDefinitions.cs
@@ -354,5 +354,11 @@
         {
             testDataContexts.First().IsNewState.Should().BeTrue();
         }
+
+        [Then(@"the session state is intialized")]
+        public void ThenTheSessionStateIsIntialized()
+        {
+            testDataContexts.First().LatestLoadedState.Should().NotBeNull();
+        }
     }
 }


### PR DESCRIPTION
For a new session with a stream that does not exist (yet), when we open the session, `IsNewState` is expected to be `true`

It is a regression, was working as expected in the previous version