### PR TITLE
Benchmark with direct comparison of the three latest versions

### DIFF
--- a/src/Benchmark/Benchmark-VersionsComparison-Full.html
+++ b/src/Benchmark/Benchmark-VersionsComparison-Full.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='utf-8' />
+<title>Benchmark.ReadEventStreamBenchmark-20230614-035404</title>
+
+<style type="text/css">
+    table { border-collapse: collapse; display: block; width: 100%; overflow: auto; }
+    td, th { padding: 6px 13px; border: 1px solid #ddd; text-align: right; }
+    tr { background-color: #fff; border-top: 1px solid #ccc; }
+    tr:nth-child(even) { background: #f8f8f8; }
+</style>
+</head>
+<body>
+<pre><code>
+BenchmarkDotNet=v0.13.5, OS=pop 22.04
+AMD Ryzen 9 7950X, 1 CPU, 32 logical and 16 physical cores
+.NET SDK=7.0.302
+  [Host]     : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+  Job-YALQSZ : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+  Job-OHALFC : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+  Job-ZGFJCK : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+</code></pre>
+<pre><code>InvocationCount=1  MaxIterationCount=50  MinIterationCount=20
+UnrollFactor=1  WarmupCount=1
+</code></pre>
+
+<table>
+<thead><tr><th>Method</th><th> Job</th><th>                          NuGetReferences</th><th>EventsCount</th><th>EventSize</th><th>  Mean</th><th>Error</th><th>StdDev</th><th>Ratio</th><th>RatioSD</th><th>Gen0</th><th>Gen1</th><th>Gen2</th><th>Allocated</th><th>Alloc Ratio</th>
+</tr>
+</thead><tbody><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10</td><td>10</td><td>1.972 ms</td><td>0.0812 ms</td><td>0.1564 ms</td><td>1.34</td><td>0.15</td><td>-</td><td>-</td><td>-</td><td>240.48 KB</td><td>1.27</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10</td><td>10</td><td>2.153 ms</td><td>0.0765 ms</td><td>0.1492 ms</td><td>1.47</td><td>0.19</td><td>-</td><td>-</td><td>-</td><td>236.44 KB</td><td>1.25</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10</td><td>10</td><td>1.484 ms</td><td>0.0793 ms</td><td>0.1583 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>188.99 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10</td><td>20</td><td>2.052 ms</td><td>0.0921 ms</td><td>0.1817 ms</td><td>1.45</td><td>0.16</td><td>-</td><td>-</td><td>-</td><td>272.87 KB</td><td>1.25</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10</td><td>20</td><td>2.141 ms</td><td>0.0957 ms</td><td>0.1866 ms</td><td>1.51</td><td>0.19</td><td>-</td><td>-</td><td>-</td><td>267.3 KB</td><td>1.23</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10</td><td>20</td><td>1.424 ms</td><td>0.0698 ms</td><td>0.1377 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>217.51 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10</td><td>50</td><td>2.063 ms</td><td>0.1188 ms</td><td>0.2345 ms</td><td>1.31</td><td>0.14</td><td>-</td><td>-</td><td>-</td><td>370.8 KB</td><td>1.24</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10</td><td>50</td><td>2.248 ms</td><td>0.1092 ms</td><td>0.2180 ms</td><td>1.43</td><td>0.16</td><td>-</td><td>-</td><td>-</td><td>356.91 KB</td><td>1.19</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10</td><td>50</td><td>1.583 ms</td><td>0.0772 ms</td><td>0.1524 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>300.09 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>100</td><td>10</td><td>3.531 ms</td><td>0.1598 ms</td><td>0.3153 ms</td><td>1.28</td><td>0.14</td><td>-</td><td>-</td><td>-</td><td>1545.34 KB</td><td>1.04</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>100</td><td>10</td><td>3.605 ms</td><td>0.1877 ms</td><td>0.3749 ms</td><td>1.31</td><td>0.18</td><td>-</td><td>-</td><td>-</td><td>1537.75 KB</td><td>1.03</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>100</td><td>10</td><td>2.782 ms</td><td>0.1483 ms</td><td>0.2858 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>1491.62 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>100</td><td>20</td><td>3.734 ms</td><td>0.2233 ms</td><td>0.4356 ms</td><td>1.40</td><td>0.23</td><td>-</td><td>-</td><td>-</td><td>1877.07 KB</td><td>1.06</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>100</td><td>20</td><td>3.589 ms</td><td>0.1940 ms</td><td>0.3785 ms</td><td>1.35</td><td>0.22</td><td>-</td><td>-</td><td>-</td><td>1818.95 KB</td><td>1.03</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>100</td><td>20</td><td>2.687 ms</td><td>0.1622 ms</td><td>0.3201 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>1769.93 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>100</td><td>50</td><td>4.243 ms</td><td>0.2421 ms</td><td>0.4834 ms</td><td>1.25</td><td>0.18</td><td>-</td><td>-</td><td>-</td><td>2653.76 KB</td><td>1.03</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>100</td><td>50</td><td>4.143 ms</td><td>0.2446 ms</td><td>0.4771 ms</td><td>1.21</td><td>0.17</td><td>-</td><td>-</td><td>-</td><td>2634.05 KB</td><td>1.02</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>100</td><td>50</td><td>3.454 ms</td><td>0.2084 ms</td><td>0.4065 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>2577.52 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>200</td><td>10</td><td>4.785 ms</td><td>0.3110 ms</td><td>0.6138 ms</td><td>1.16</td><td>0.23</td><td>-</td><td>-</td><td>-</td><td>3000.79 KB</td><td>1.02</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>200</td><td>10</td><td>5.137 ms</td><td>0.3363 ms</td><td>0.6398 ms</td><td>1.25</td><td>0.26</td><td>-</td><td>-</td><td>-</td><td>3001.02 KB</td><td>1.02</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>200</td><td>10</td><td>4.227 ms</td><td>0.3434 ms</td><td>0.6858 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>2938.09 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>200</td><td>20</td><td>5.200 ms</td><td>0.3704 ms</td><td>0.7311 ms</td><td>1.10</td><td>0.17</td><td>-</td><td>-</td><td>-</td><td>3562.96 KB</td><td>0.99</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>200</td><td>20</td><td>5.236 ms</td><td>0.3167 ms</td><td>0.6251 ms</td><td>1.12</td><td>0.21</td><td>-</td><td>-</td><td>-</td><td>3544.75 KB</td><td>0.98</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>200</td><td>20</td><td>4.777 ms</td><td>0.3185 ms</td><td>0.6288 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>3615.97 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>200</td><td>50</td><td>6.271 ms</td><td>0.4774 ms</td><td>0.9312 ms</td><td>1.11</td><td>0.24</td><td>-</td><td>-</td><td>-</td><td>5237.12 KB</td><td>1.03</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>200</td><td>50</td><td>6.410 ms</td><td>0.5287 ms</td><td>1.0312 ms</td><td>1.14</td><td>0.25</td><td>-</td><td>-</td><td>-</td><td>5164.94 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>200</td><td>50</td><td>5.741 ms</td><td>0.4346 ms</td><td>0.8579 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>5108.82 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>500</td><td>10</td><td>8.922 ms</td><td>1.0411 ms</td><td>2.0305 ms</td><td>1.10</td><td>0.24</td><td>-</td><td>-</td><td>-</td><td>7676.41 KB</td><td>1.05</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>500</td><td>10</td><td>9.404 ms</td><td>0.8784 ms</td><td>1.7133 ms</td><td>1.17</td><td>0.27</td><td>-</td><td>-</td><td>-</td><td>7327.84 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>500</td><td>10</td><td>8.154 ms</td><td>0.5982 ms</td><td>1.1807 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>7280.56 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>500</td><td>20</td><td>9.972 ms</td><td>0.9272 ms</td><td>1.8083 ms</td><td>1.10</td><td>0.25</td><td>-</td><td>-</td><td>-</td><td>8764.92 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>500</td><td>20</td><td>9.962 ms</td><td>0.7742 ms</td><td>1.5100 ms</td><td>1.09</td><td>0.20</td><td>-</td><td>-</td><td>-</td><td>8721.88 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>500</td><td>20</td><td>9.160 ms</td><td>0.7662 ms</td><td>1.5478 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>8672.55 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>500</td><td>50</td><td>14.376 ms</td><td>1.5914 ms</td><td>3.1782 ms</td><td>1.16</td><td>0.30</td><td>-</td><td>-</td><td>-</td><td>12802.35 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>500</td><td>50</td><td>14.023 ms</td><td>1.2062 ms</td><td>2.3809 ms</td><td>1.15</td><td>0.29</td><td>-</td><td>-</td><td>-</td><td>13054.03 KB</td><td>1.03</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>500</td><td>50</td><td>12.679 ms</td><td>1.1640 ms</td><td>2.3247 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>12701.2 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>1000</td><td>10</td><td>16.835 ms</td><td>1.6770 ms</td><td>3.3491 ms</td><td>0.95</td><td>0.22</td><td>-</td><td>-</td><td>-</td><td>15007.77 KB</td><td>1.03</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>1000</td><td>10</td><td>16.463 ms</td><td>1.9818 ms</td><td>3.9119 ms</td><td>0.94</td><td>0.29</td><td>-</td><td>-</td><td>-</td><td>14565.54 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>1000</td><td>10</td><td>17.970 ms</td><td>1.2447 ms</td><td>2.5144 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>14534.39 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>1000</td><td>20</td><td>19.182 ms</td><td>1.8746 ms</td><td>3.6563 ms</td><td>1.23</td><td>0.31</td><td>-</td><td>-</td><td>-</td><td>17417.84 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>1000</td><td>20</td><td>18.119 ms</td><td>1.8693 ms</td><td>3.7762 ms</td><td>1.17</td><td>0.31</td><td>-</td><td>-</td><td>-</td><td>17350 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>1000</td><td>20</td><td>15.838 ms</td><td>1.2518 ms</td><td>2.5287 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>17300.74 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>1000</td><td>50</td><td>25.645 ms</td><td>2.4311 ms</td><td>4.9109 ms</td><td>1.20</td><td>0.25</td><td>-</td><td>-</td><td>-</td><td>25488.89 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>1000</td><td>50</td><td>26.944 ms</td><td>3.0440 ms</td><td>6.1491 ms</td><td>1.27</td><td>0.35</td><td>-</td><td>-</td><td>-</td><td>25693.54 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>1000</td><td>50</td><td>21.789 ms</td><td>1.3357 ms</td><td>2.6051 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>25593.7 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>2000</td><td>10</td><td>30.445 ms</td><td>3.2625 ms</td><td>6.5155 ms</td><td>0.87</td><td>0.20</td><td>-</td><td>-</td><td>-</td><td>29167.88 KB</td><td>0.99</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>2000</td><td>10</td><td>35.324 ms</td><td>2.9129 ms</td><td>5.8174 ms</td><td>1.02</td><td>0.27</td><td>-</td><td>-</td><td>-</td><td>29209.91 KB</td><td>0.99</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>2000</td><td>10</td><td>35.546 ms</td><td>2.6684 ms</td><td>5.3902 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>29603.45 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>2000</td><td>20</td><td>34.541 ms</td><td>3.4224 ms</td><td>6.8349 ms</td><td>1.01</td><td>0.32</td><td>-</td><td>-</td><td>-</td><td>34739.19 KB</td><td>0.97</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>2000</td><td>20</td><td>35.462 ms</td><td>3.5216 ms</td><td>7.1138 ms</td><td>1.03</td><td>0.30</td><td>-</td><td>-</td><td>-</td><td>34607.35 KB</td><td>0.97</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>2000</td><td>20</td><td>36.082 ms</td><td>3.8716 ms</td><td>7.8209 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>35743.64 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>2000</td><td>50</td><td>46.349 ms</td><td>4.4479 ms</td><td>8.9850 ms</td><td>0.96</td><td>0.24</td><td>-</td><td>-</td><td>-</td><td>51055.11 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>2000</td><td>50</td><td>48.834 ms</td><td>4.8035 ms</td><td>9.7033 ms</td><td>1.00</td><td>0.24</td><td>-</td><td>-</td><td>-</td><td>51415.52 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>2000</td><td>50</td><td>49.642 ms</td><td>3.5697 ms</td><td>7.2110 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>50667.09 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>5000</td><td>10</td><td>72.013 ms</td><td>5.0281 ms</td><td>10.1571 ms</td><td>0.98</td><td>0.22</td><td>-</td><td>-</td><td>-</td><td>75728.15 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>5000</td><td>10</td><td>76.872 ms</td><td>4.7346 ms</td><td>9.5642 ms</td><td>1.04</td><td>0.18</td><td>-</td><td>-</td><td>-</td><td>75476.92 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>5000</td><td>10</td><td>74.740 ms</td><td>4.2599 ms</td><td>8.6052 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>75465.1 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>5000</td><td>20</td><td>98.985 ms</td><td>5.0816 ms</td><td>10.2651 ms</td><td>1.28</td><td>0.25</td><td>1000.0000</td><td>-</td><td>-</td><td>89765.91 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>5000</td><td>20</td><td>79.809 ms</td><td>5.0691 ms</td><td>10.2399 ms</td><td>1.03</td><td>0.22</td><td>1000.0000</td><td>-</td><td>-</td><td>86376.94 KB</td><td>0.97</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>5000</td><td>20</td><td>78.990 ms</td><td>5.4281 ms</td><td>10.9650 ms</td><td>1.00</td><td>0.00</td><td>1000.0000</td><td>-</td><td>-</td><td>89374.01 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>5000</td><td>50</td><td>122.042 ms</td><td>6.2967 ms</td><td>12.7196 ms</td><td>1.22</td><td>0.16</td><td>1000.0000</td><td>-</td><td>-</td><td>129950.29 KB</td><td>1.02</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>5000</td><td>50</td><td>101.555 ms</td><td>4.7927 ms</td><td>9.6814 ms</td><td>1.02</td><td>0.17</td><td>1000.0000</td><td>-</td><td>-</td><td>129531.66 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>5000</td><td>50</td><td>101.275 ms</td><td>5.5051 ms</td><td>11.1206 ms</td><td>1.00</td><td>0.00</td><td>1000.0000</td><td>-</td><td>-</td><td>127780.62 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10000</td><td>10</td><td>143.305 ms</td><td>5.5475 ms</td><td>11.2061 ms</td><td>1.13</td><td>0.11</td><td>1000.0000</td><td>-</td><td>-</td><td>151657.59 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10000</td><td>10</td><td>125.930 ms</td><td>7.8462 ms</td><td>15.8497 ms</td><td>0.99</td><td>0.17</td><td>1000.0000</td><td>-</td><td>-</td><td>147378.52 KB</td><td>0.98</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10000</td><td>10</td><td>128.015 ms</td><td>6.0849 ms</td><td>12.2918 ms</td><td>1.00</td><td>0.00</td><td>1000.0000</td><td>-</td><td>-</td><td>150876.3 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10000</td><td>20</td><td>181.672 ms</td><td>7.4506 ms</td><td>15.0507 ms</td><td>1.34</td><td>0.20</td><td>2000.0000</td><td>1000.0000</td><td>-</td><td>179312.89 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10000</td><td>20</td><td>139.970 ms</td><td>7.3741 ms</td><td>14.8959 ms</td><td>1.03</td><td>0.16</td><td>2000.0000</td><td>-</td><td>-</td><td>178557.24 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10000</td><td>20</td><td>137.015 ms</td><td>6.9285 ms</td><td>13.9960 ms</td><td>1.00</td><td>0.00</td><td>2000.0000</td><td>-</td><td>-</td><td>176991.53 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10000</td><td>50</td><td>258.005 ms</td><td>6.5409 ms</td><td>13.2128 ms</td><td>1.41</td><td>0.14</td><td>4000.0000</td><td>2000.0000</td><td>1000.0000</td><td>260019.34 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10000</td><td>50</td><td>189.503 ms</td><td>7.3966 ms</td><td>14.9414 ms</td><td>1.03</td><td>0.11</td><td>3000.0000</td><td>-</td><td>-</td><td>258160.49 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10000</td><td>50</td><td>185.170 ms</td><td>7.9989 ms</td><td>15.9746 ms</td><td>1.00</td><td>0.00</td><td>3000.0000</td><td>-</td><td>-</td><td>258358.69 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>20000</td><td>10</td><td>305.691 ms</td><td>8.5957 ms</td><td>17.3638 ms</td><td>1.32</td><td>0.10</td><td>4000.0000</td><td>2000.0000</td><td>1000.0000</td><td>302683.97 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>20000</td><td>10</td><td>236.187 ms</td><td>8.3970 ms</td><td>16.9623 ms</td><td>1.02</td><td>0.10</td><td>3000.0000</td><td>-</td><td>-</td><td>300281.78 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>20000</td><td>10</td><td>233.227 ms</td><td>7.3597 ms</td><td>14.5273 ms</td><td>1.00</td><td>0.00</td><td>3000.0000</td><td>-</td><td>-</td><td>301692.14 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>20000</td><td>20</td><td>372.393 ms</td><td>8.0419 ms</td><td>15.6851 ms</td><td>1.44</td><td>0.10</td><td>5000.0000</td><td>3000.0000</td><td>1000.0000</td><td>356947.79 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>20000</td><td>20</td><td>257.338 ms</td><td>7.8518 ms</td><td>15.8610 ms</td><td>0.99</td><td>0.08</td><td>4000.0000</td><td>-</td><td>-</td><td>357416.42 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>20000</td><td>20</td><td>259.824 ms</td><td>6.7273 ms</td><td>13.4352 ms</td><td>1.00</td><td>0.00</td><td>4000.0000</td><td>-</td><td>-</td><td>357344.98 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>20000</td><td>50</td><td>530.442 ms</td><td>11.9390 ms</td><td>24.1173 ms</td><td>1.56</td><td>0.12</td><td>8000.0000</td><td>5000.0000</td><td>2000.0000</td><td>519908.74 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>20000</td><td>50</td><td>345.357 ms</td><td>9.1022 ms</td><td>18.3868 ms</td><td>1.01</td><td>0.07</td><td>6000.0000</td><td>-</td><td>-</td><td>515735.3 KB</td><td>0.99</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>20000</td><td>50</td><td>341.783 ms</td><td>9.3933 ms</td><td>18.9750 ms</td><td>1.00</td><td>0.00</td><td>6000.0000</td><td>-</td><td>-</td><td>518380.2 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>50000</td><td>10</td><td>820.913 ms</td><td>16.0551 ms</td><td>24.5178 ms</td><td>1.55</td><td>0.10</td><td>12000.0000</td><td>8000.0000</td><td>3000.0000</td><td>754612.04 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>50000</td><td>10</td><td>532.840 ms</td><td>11.8653 ms</td><td>23.9685 ms</td><td>1.01</td><td>0.06</td><td>9000.0000</td><td>-</td><td>-</td><td>750435.42 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>50000</td><td>10</td><td>529.389 ms</td><td>12.3783 ms</td><td>25.0048 ms</td><td>1.00</td><td>0.00</td><td>9000.0000</td><td>-</td><td>-</td><td>751830.63 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>50000</td><td>20</td><td>938.902 ms</td><td>18.7112 ms</td><td>22.2744 ms</td><td>1.54</td><td>0.07</td><td>12000.0000</td><td>7000.0000</td><td>2000.0000</td><td>894917.77 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>50000</td><td>20</td><td>602.347 ms</td><td>13.4747 ms</td><td>27.2196 ms</td><td>0.98</td><td>0.06</td><td>10000.0000</td><td>-</td><td>-</td><td>893057.38 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>50000</td><td>20</td><td>616.156 ms</td><td>12.1570 ms</td><td>20.9702 ms</td><td>1.00</td><td>0.00</td><td>10000.0000</td><td>-</td><td>-</td><td>893055.61 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>50000</td><td>50</td><td>1,337.780 ms</td><td>26.2376 ms</td><td>44.5535 ms</td><td>1.77</td><td>0.09</td><td>19000.0000</td><td>14000.0000</td><td>4000.0000</td><td>1299470.27 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>50000</td><td>50</td><td>763.488 ms</td><td>15.2580 ms</td><td>25.4927 ms</td><td>1.01</td><td>0.04</td><td>15000.0000</td><td>1000.0000</td><td>-</td><td>1293865.5 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>50000</td><td>50</td><td>755.570 ms</td><td>14.7546 ms</td><td>24.6516 ms</td><td>1.00</td><td>0.00</td><td>15000.0000</td><td>1000.0000</td><td>-</td><td>1295717.35 KB</td><td>1.00</td>
+</tr></tbody></table>
+</body>
+</html>

--- a/src/Benchmark/Benchmark-VersionsComparison-Short.html
+++ b/src/Benchmark/Benchmark-VersionsComparison-Short.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='utf-8' />
+<title>Benchmark.ReadEventStreamBenchmark-20230614-035404</title>
+
+<style type="text/css">
+	table { border-collapse: collapse; display: block; width: 100%; overflow: auto; }
+	td, th { padding: 6px 13px; border: 1px solid #ddd; text-align: right; }
+	tr { background-color: #fff; border-top: 1px solid #ccc; }
+	tr:nth-child(even) { background: #f8f8f8; }
+</style>
+</head>
+<body>
+<pre><code>
+BenchmarkDotNet=v0.13.5, OS=pop 22.04
+AMD Ryzen 9 7950X, 1 CPU, 32 logical and 16 physical cores
+.NET SDK=7.0.302
+  [Host]     : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+  Job-YALQSZ : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+  Job-OHALFC : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+  Job-ZGFJCK : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+</code></pre>
+<pre><code>InvocationCount=1  MaxIterationCount=50  MinIterationCount=20  
+UnrollFactor=1  WarmupCount=1  
+</code></pre>
+
+<table>
+<thead><tr><th>Method</th><th> Job</th><th>                          NuGetReferences</th><th>EventsCount</th><th>EventSize</th><th>  Mean</th><th>Error</th><th>StdDev</th><th>Ratio</th><th>RatioSD</th><th>Gen0</th><th>Gen1</th><th>Gen2</th><th>Allocated</th><th>Alloc Ratio</th>
+</tr>
+</thead><tbody><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10</td><td>10</td><td>1.972 ms</td><td>0.0812 ms</td><td>0.1564 ms</td><td>1.34</td><td>0.15</td><td>-</td><td>-</td><td>-</td><td>240.48 KB</td><td>1.27</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10</td><td>10</td><td>2.153 ms</td><td>0.0765 ms</td><td>0.1492 ms</td><td>1.47</td><td>0.19</td><td>-</td><td>-</td><td>-</td><td>236.44 KB</td><td>1.25</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10</td><td>10</td><td>1.484 ms</td><td>0.0793 ms</td><td>0.1583 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>188.99 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10</td><td>20</td><td>2.052 ms</td><td>0.0921 ms</td><td>0.1817 ms</td><td>1.45</td><td>0.16</td><td>-</td><td>-</td><td>-</td><td>272.87 KB</td><td>1.25</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10</td><td>20</td><td>2.141 ms</td><td>0.0957 ms</td><td>0.1866 ms</td><td>1.51</td><td>0.19</td><td>-</td><td>-</td><td>-</td><td>267.3 KB</td><td>1.23</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10</td><td>20</td><td>1.424 ms</td><td>0.0698 ms</td><td>0.1377 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>217.51 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10</td><td>50</td><td>2.063 ms</td><td>0.1188 ms</td><td>0.2345 ms</td><td>1.31</td><td>0.14</td><td>-</td><td>-</td><td>-</td><td>370.8 KB</td><td>1.24</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10</td><td>50</td><td>2.248 ms</td><td>0.1092 ms</td><td>0.2180 ms</td><td>1.43</td><td>0.16</td><td>-</td><td>-</td><td>-</td><td>356.91 KB</td><td>1.19</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10</td><td>50</td><td>1.583 ms</td><td>0.0772 ms</td><td>0.1524 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>300.09 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>100</td><td>20</td><td>3.734 ms</td><td>0.2233 ms</td><td>0.4356 ms</td><td>1.40</td><td>0.23</td><td>-</td><td>-</td><td>-</td><td>1877.07 KB</td><td>1.06</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>100</td><td>20</td><td>3.589 ms</td><td>0.1940 ms</td><td>0.3785 ms</td><td>1.35</td><td>0.22</td><td>-</td><td>-</td><td>-</td><td>1818.95 KB</td><td>1.03</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>100</td><td>20</td><td>2.687 ms</td><td>0.1622 ms</td><td>0.3201 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>1769.93 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>200</td><td>20</td><td>5.200 ms</td><td>0.3704 ms</td><td>0.7311 ms</td><td>1.10</td><td>0.17</td><td>-</td><td>-</td><td>-</td><td>3562.96 KB</td><td>0.99</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>200</td><td>20</td><td>5.236 ms</td><td>0.3167 ms</td><td>0.6251 ms</td><td>1.12</td><td>0.21</td><td>-</td><td>-</td><td>-</td><td>3544.75 KB</td><td>0.98</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>200</td><td>20</td><td>4.777 ms</td><td>0.3185 ms</td><td>0.6288 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>3615.97 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>500</td><td>20</td><td>9.972 ms</td><td>0.9272 ms</td><td>1.8083 ms</td><td>1.10</td><td>0.25</td><td>-</td><td>-</td><td>-</td><td>8764.92 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>500</td><td>20</td><td>9.962 ms</td><td>0.7742 ms</td><td>1.5100 ms</td><td>1.09</td><td>0.20</td><td>-</td><td>-</td><td>-</td><td>8721.88 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>500</td><td>20</td><td>9.160 ms</td><td>0.7662 ms</td><td>1.5478 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>8672.55 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>1000</td><td>20</td><td>19.182 ms</td><td>1.8746 ms</td><td>3.6563 ms</td><td>1.23</td><td>0.31</td><td>-</td><td>-</td><td>-</td><td>17417.84 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>1000</td><td>20</td><td>18.119 ms</td><td>1.8693 ms</td><td>3.7762 ms</td><td>1.17</td><td>0.31</td><td>-</td><td>-</td><td>-</td><td>17350 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>1000</td><td>20</td><td>15.838 ms</td><td>1.2518 ms</td><td>2.5287 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>17300.74 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>2000</td><td>20</td><td>34.541 ms</td><td>3.4224 ms</td><td>6.8349 ms</td><td>1.01</td><td>0.32</td><td>-</td><td>-</td><td>-</td><td>34739.19 KB</td><td>0.97</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>2000</td><td>20</td><td>35.462 ms</td><td>3.5216 ms</td><td>7.1138 ms</td><td>1.03</td><td>0.30</td><td>-</td><td>-</td><td>-</td><td>34607.35 KB</td><td>0.97</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>2000</td><td>20</td><td>36.082 ms</td><td>3.8716 ms</td><td>7.8209 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>35743.64 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>5000</td><td>20</td><td>98.985 ms</td><td>5.0816 ms</td><td>10.2651 ms</td><td>1.28</td><td>0.25</td><td>1000.0000</td><td>-</td><td>-</td><td>89765.91 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>5000</td><td>20</td><td>79.809 ms</td><td>5.0691 ms</td><td>10.2399 ms</td><td>1.03</td><td>0.22</td><td>1000.0000</td><td>-</td><td>-</td><td>86376.94 KB</td><td>0.97</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>5000</td><td>20</td><td>78.990 ms</td><td>5.4281 ms</td><td>10.9650 ms</td><td>1.00</td><td>0.00</td><td>1000.0000</td><td>-</td><td>-</td><td>89374.01 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>10000</td><td>20</td><td>181.672 ms</td><td>7.4506 ms</td><td>15.0507 ms</td><td>1.34</td><td>0.20</td><td>2000.0000</td><td>1000.0000</td><td>-</td><td>179312.89 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>10000</td><td>20</td><td>139.970 ms</td><td>7.3741 ms</td><td>14.8959 ms</td><td>1.03</td><td>0.16</td><td>2000.0000</td><td>-</td><td>-</td><td>178557.24 KB</td><td>1.01</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>10000</td><td>20</td><td>137.015 ms</td><td>6.9285 ms</td><td>13.9960 ms</td><td>1.00</td><td>0.00</td><td>2000.0000</td><td>-</td><td>-</td><td>176991.53 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>20000</td><td>20</td><td>372.393 ms</td><td>8.0419 ms</td><td>15.6851 ms</td><td>1.44</td><td>0.10</td><td>5000.0000</td><td>3000.0000</td><td>1000.0000</td><td>356947.79 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>20000</td><td>20</td><td>257.338 ms</td><td>7.8518 ms</td><td>15.8610 ms</td><td>0.99</td><td>0.08</td><td>4000.0000</td><td>-</td><td>-</td><td>357416.42 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>20000</td><td>20</td><td>259.824 ms</td><td>6.7273 ms</td><td>13.4352 ms</td><td>1.00</td><td>0.00</td><td>4000.0000</td><td>-</td><td>-</td><td>357344.98 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>50000</td><td>10</td><td>820.913 ms</td><td>16.0551 ms</td><td>24.5178 ms</td><td>1.55</td><td>0.10</td><td>12000.0000</td><td>8000.0000</td><td>3000.0000</td><td>754612.04 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>50000</td><td>10</td><td>532.840 ms</td><td>11.8653 ms</td><td>23.9685 ms</td><td>1.01</td><td>0.06</td><td>9000.0000</td><td>-</td><td>-</td><td>750435.42 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>50000</td><td>10</td><td>529.389 ms</td><td>12.3783 ms</td><td>25.0048 ms</td><td>1.00</td><td>0.00</td><td>9000.0000</td><td>-</td><td>-</td><td>751830.63 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>50000</td><td>20</td><td>938.902 ms</td><td>18.7112 ms</td><td>22.2744 ms</td><td>1.54</td><td>0.07</td><td>12000.0000</td><td>7000.0000</td><td>2000.0000</td><td>894917.77 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>50000</td><td>20</td><td>602.347 ms</td><td>13.4747 ms</td><td>27.2196 ms</td><td>0.98</td><td>0.06</td><td>10000.0000</td><td>-</td><td>-</td><td>893057.38 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>50000</td><td>20</td><td>616.156 ms</td><td>12.1570 ms</td><td>20.9702 ms</td><td>1.00</td><td>0.00</td><td>10000.0000</td><td>-</td><td>-</td><td>893055.61 KB</td><td>1.00</td>
+</tr><tr><td colspan="15">---</td>
+
+</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>50000</td><td>50</td><td>1,337.780 ms</td><td>26.2376 ms</td><td>44.5535 ms</td><td>1.77</td><td>0.09</td><td>19000.0000</td><td>14000.0000</td><td>4000.0000</td><td>1299470.27 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>50000</td><td>50</td><td>763.488 ms</td><td>15.2580 ms</td><td>25.4927 ms</td><td>1.01</td><td>0.04</td><td>15000.0000</td><td>1000.0000</td><td>-</td><td>1293865.5 KB</td><td>1.00</td>
+</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>50000</td><td>50</td><td>755.570 ms</td><td>14.7546 ms</td><td>24.6516 ms</td><td>1.00</td><td>0.00</td><td>15000.0000</td><td>1000.0000</td><td>-</td><td>1295717.35 KB</td><td>1.00</td>
+</tr></tbody></table>
+</body>
+</html>

--- a/src/Benchmark/Benchmark-VersionsComparison-Short.html
+++ b/src/Benchmark/Benchmark-VersionsComparison-Short.html
@@ -48,11 +48,6 @@ UnrollFactor=1  WarmupCount=1
 </tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>100</td><td>20</td><td>2.687 ms</td><td>0.1622 ms</td><td>0.3201 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>1769.93 KB</td><td>1.00</td>
 </tr><tr><td colspan="15">---</td>
 
-</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>200</td><td>20</td><td>5.200 ms</td><td>0.3704 ms</td><td>0.7311 ms</td><td>1.10</td><td>0.17</td><td>-</td><td>-</td><td>-</td><td>3562.96 KB</td><td>0.99</td>
-</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>200</td><td>20</td><td>5.236 ms</td><td>0.3167 ms</td><td>0.6251 ms</td><td>1.12</td><td>0.21</td><td>-</td><td>-</td><td>-</td><td>3544.75 KB</td><td>0.98</td>
-</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>200</td><td>20</td><td>4.777 ms</td><td>0.3185 ms</td><td>0.6288 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>3615.97 KB</td><td>1.00</td>
-</tr><tr><td colspan="15">---</td>
-
 </tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>500</td><td>20</td><td>9.972 ms</td><td>0.9272 ms</td><td>1.8083 ms</td><td>1.10</td><td>0.25</td><td>-</td><td>-</td><td>-</td><td>8764.92 KB</td><td>1.01</td>
 </tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>500</td><td>20</td><td>9.962 ms</td><td>0.7742 ms</td><td>1.5100 ms</td><td>1.09</td><td>0.20</td><td>-</td><td>-</td><td>-</td><td>8721.88 KB</td><td>1.01</td>
 </tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>500</td><td>20</td><td>9.160 ms</td><td>0.7662 ms</td><td>1.5478 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>8672.55 KB</td><td>1.00</td>
@@ -61,11 +56,6 @@ UnrollFactor=1  WarmupCount=1
 </tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>1000</td><td>20</td><td>19.182 ms</td><td>1.8746 ms</td><td>3.6563 ms</td><td>1.23</td><td>0.31</td><td>-</td><td>-</td><td>-</td><td>17417.84 KB</td><td>1.01</td>
 </tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>1000</td><td>20</td><td>18.119 ms</td><td>1.8693 ms</td><td>3.7762 ms</td><td>1.17</td><td>0.31</td><td>-</td><td>-</td><td>-</td><td>17350 KB</td><td>1.00</td>
 </tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>1000</td><td>20</td><td>15.838 ms</td><td>1.2518 ms</td><td>2.5287 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>17300.74 KB</td><td>1.00</td>
-</tr><tr><td colspan="15">---</td>
-
-</tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>2000</td><td>20</td><td>34.541 ms</td><td>3.4224 ms</td><td>6.8349 ms</td><td>1.01</td><td>0.32</td><td>-</td><td>-</td><td>-</td><td>34739.19 KB</td><td>0.97</td>
-</tr><tr><td>LoadStream</td><td>Job-OHALFC</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-023</td><td>2000</td><td>20</td><td>35.462 ms</td><td>3.5216 ms</td><td>7.1138 ms</td><td>1.03</td><td>0.30</td><td>-</td><td>-</td><td>-</td><td>34607.35 KB</td><td>0.97</td>
-</tr><tr><td>LoadStream</td><td>Job-ZGFJCK</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-024</td><td>2000</td><td>20</td><td>36.082 ms</td><td>3.8716 ms</td><td>7.8209 ms</td><td>1.00</td><td>0.00</td><td>-</td><td>-</td><td>-</td><td>35743.64 KB</td><td>1.00</td>
 </tr><tr><td colspan="15">---</td>
 
 </tr><tr><td>LoadStream</td><td>Job-YALQSZ</td><td>BullOak.Repositories.EventStore 3.0.0-alpha-021</td><td>5000</td><td>20</td><td>98.985 ms</td><td>5.0816 ms</td><td>10.2651 ms</td><td>1.28</td><td>0.25</td><td>1000.0000</td><td>-</td><td>-</td><td>89765.91 KB</td><td>1.00</td>

--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -9,10 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\BullOak.Repositories.EventStore\BullOak.Repositories.EventStore.csproj" />
+      <PackageReference Include="BullOak.Repositories.EventStore" Version="3.0.0-alpha-020" />
     </ItemGroup>
 
 </Project>

--- a/src/Benchmark/BullOakVersionsConfig.cs
+++ b/src/Benchmark/BullOakVersionsConfig.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+namespace Benchmark;
+
+public class BullOakVersionsConfig : ManualConfig
+{
+    public BullOakVersionsConfig()
+    {
+        WithOptions(ConfigOptions.Default);
+
+        var baseJob = Job.Default;
+
+        const string nugetPackage = "BullOak.Repositories.EventStore";
+        var nugetPackageVersions = new[]
+        {
+            ("3.0.0-alpha-024", true),
+            ("3.0.0-alpha-023", false),
+            ("3.0.0-alpha-021", false)
+        };
+
+        foreach (var (version, isBaseline) in nugetPackageVersions)
+        {
+            AddJob(baseJob
+                .WithNuGet(nugetPackage, version)
+                .WithId(version)
+                .WithBaseline(isBaseline));
+        }
+    }
+}

--- a/src/Benchmark/README.md
+++ b/src/Benchmark/README.md
@@ -94,6 +94,60 @@ docker volume prune -f
 
 ## Results
 
+### Comparing versions 3.0.0-alpha24, 3.0.0-alpha23, 3.0.0-alpha21
+
+Benchmark results directly comparing 3 latest versions:
+
+* [Full report](./Benchmark-VersionsComparison-Full.html)
+* [Short report](./Benchmark-VersionsComparison-Short.html) with most
+  permutations excluded, it is easier to read but still provides a good overview
+
+### `BullOak.EventStore` 3.0.0-alpha24
+
+```ini
+BenchmarkDotNet=v0.13.5, OS=pop 22.04
+AMD Ryzen 9 7950X, 1 CPU, 32 logical and 16 physical cores
+.NET SDK=7.0.302
+  [Host]     : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+  Job-FSGJAI : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
+
+InvocationCount=1  MaxIterationCount=50  MinIterationCount=20
+UnrollFactor=1  WarmupCount=1
+```
+
+|     Method | EventsCount | EventSize |       Mean |      Error |     StdDev |       Gen0 |      Gen1 |     Allocated |
+|----------- |------------ |---------- |-----------:|-----------:|-----------:|-----------:|----------:|--------------:|
+| LoadStream |          10 |        10 |   1.552 ms |  0.0940 ms |  0.1877 ms |          - |         - |     188.55 KB |
+| LoadStream |          10 |        20 |   1.532 ms |  0.0748 ms |  0.1459 ms |          - |         - |     216.82 KB |
+| LoadStream |          10 |        50 |   1.492 ms |  0.0818 ms |  0.1575 ms |          - |         - |      299.4 KB |
+| LoadStream |         100 |        10 |   2.801 ms |  0.1850 ms |  0.3736 ms |          - |         - |    1545.11 KB |
+| LoadStream |         100 |        20 |   3.048 ms |  0.1800 ms |  0.3594 ms |          - |         - |    1763.38 KB |
+| LoadStream |         100 |        50 |   3.624 ms |  0.2956 ms |  0.5904 ms |          - |         - |    2571.34 KB |
+| LoadStream |         200 |        10 |   4.320 ms |  0.2714 ms |  0.5357 ms |          - |         - |    2925.52 KB |
+| LoadStream |         200 |        20 |   4.304 ms |  0.2418 ms |  0.4659 ms |          - |         - |    3482.82 KB |
+| LoadStream |         200 |        50 |   5.552 ms |  0.3599 ms |  0.7104 ms |          - |         - |    5096.26 KB |
+| LoadStream |         500 |        10 |   8.584 ms |  0.8805 ms |  1.7380 ms |          - |         - |    7249.25 KB |
+| LoadStream |         500 |        20 |   8.900 ms |  0.7306 ms |  1.4592 ms |          - |         - |    8641.35 KB |
+| LoadStream |         500 |        50 |  12.822 ms |  1.0406 ms |  2.1021 ms |          - |         - |   12970.44 KB |
+| LoadStream |        1000 |        10 |  17.849 ms |  1.7595 ms |  3.5138 ms |          - |         - |   15063.75 KB |
+| LoadStream |        1000 |        20 |  17.543 ms |  1.1593 ms |  2.2610 ms |          - |         - |   17703.13 KB |
+| LoadStream |        1000 |        50 |  25.648 ms |  1.9724 ms |  3.9391 ms |          - |         - |   25294.23 KB |
+| LoadStream |        2000 |        10 |  30.015 ms |  2.3754 ms |  4.6331 ms |          - |         - |   30084.53 KB |
+| LoadStream |        2000 |        20 |  32.220 ms |  2.6758 ms |  5.1554 ms |          - |         - |   35414.64 KB |
+| LoadStream |        2000 |        50 |  45.455 ms |  3.6696 ms |  7.4127 ms |          - |         - |   51143.98 KB |
+| LoadStream |        5000 |        10 |  70.871 ms |  4.7333 ms |  9.3432 ms |          - |         - |   75141.59 KB |
+| LoadStream |        5000 |        20 |  82.555 ms |  4.4087 ms |  8.8046 ms |  1000.0000 |         - |   86387.01 KB |
+| LoadStream |        5000 |        50 |  97.967 ms |  4.4871 ms |  8.9612 ms |  1000.0000 |         - |  128826.98 KB |
+| LoadStream |       10000 |        10 | 124.212 ms |  5.3951 ms | 10.8984 ms |  1000.0000 |         - |  150033.38 KB |
+| LoadStream |       10000 |        20 | 146.099 ms |  5.9870 ms | 11.9567 ms |  2000.0000 |         - |  178077.86 KB |
+| LoadStream |       10000 |        50 | 183.048 ms |  7.0636 ms | 14.2689 ms |  3000.0000 |         - |  255811.01 KB |
+| LoadStream |       20000 |        10 | 229.650 ms |  7.2827 ms | 14.7115 ms |  3000.0000 |         - |  298309.46 KB |
+| LoadStream |       20000 |        20 | 257.823 ms |  7.4720 ms | 15.0939 ms |  4000.0000 |         - |  356043.27 KB |
+| LoadStream |       20000 |        50 | 333.234 ms | 10.3116 ms | 20.8299 ms |  6000.0000 |         - |  516585.06 KB |
+| LoadStream |       50000 |        10 | 532.740 ms | 12.7867 ms | 25.8297 ms |  9000.0000 |         - |  751012.45 KB |
+| LoadStream |       50000 |        20 | 580.832 ms | 12.3614 ms | 24.6870 ms | 10000.0000 |         - |  889961.38 KB |
+| LoadStream |       50000 |        50 | 804.877 ms | 16.0397 ms | 26.7987 ms | 15000.0000 | 1000.0000 | 1290127.38 KB |
+
 ### `BullOak.EventStore` 3.0.0-alpha23
 
 ```ini

--- a/src/Benchmark/README.md
+++ b/src/Benchmark/README.md
@@ -96,7 +96,7 @@ docker volume prune -f
 
 ### Comparing versions 3.0.0-alpha24, 3.0.0-alpha23, 3.0.0-alpha21
 
-Benchmark results directly comparing 3 latest versions:
+Benchmark results directly comparing 3 last versions:
 
 * [Full report](./Benchmark-VersionsComparison-Full.html)
 * [Short report](./Benchmark-VersionsComparison-Short.html) with most

--- a/src/Benchmark/ReadEventStreamBenchmark.cs
+++ b/src/Benchmark/ReadEventStreamBenchmark.cs
@@ -8,6 +8,7 @@ using EventStore.Client;
 
 namespace Benchmark;
 
+[Config(typeof(BullOakVersionsConfig))]
 [MemoryDiagnoser]
 public class ReadEventStreamBenchmark : BenchmarkParameters
 {


### PR DESCRIPTION
Using BenchmarkDotNet feature where it can dynamically load desired version of Nuget package. This allowed us to have a report with direct comparison of last three versions of `BullOak.Repositories.EventStore` - `3.0.0-alpha-021`, `3.0.0-alpha-023`, and `3.0.0-alpha-024`.

Results show noticeable improvement in both execution time and memory allocations for small streams in `3.0.0-alpha-024` compared to `3.0.0-alpha-023`. This difference gets progressively smaller as the stream size increases, and for large streams (tens thousands of events), `3.0.0-alpha-024` is almost identical in terms of execution time and memory allocations compared to `3.0.0-alpha-023`.

![BOES-Benchmark-alpha24](https://github.com/BullOak/BullOak.Repositories.EventStore/assets/87576/e29bd8ab-425b-49cd-9886-c902176d258d)
